### PR TITLE
Make rust_repo(patch) apply the patch

### DIFF
--- a/build_defs/rust.build_defs
+++ b/build_defs/rust.build_defs
@@ -1337,7 +1337,10 @@ def rust_repo(
         install: Targets to export (defaults to [crate]). Only used if name is set.
         deps: Additional dependencies not in Cargo.toml.
         hashes: Optional hashes to verify the download.
-        patch: Patch files to apply.
+        patch: Patch files applied to the crate after it is unpacked and
+               before its BUILD files are generated, so generation sees
+               the patched manifest. Applied with `patch -p1` from the
+               crate root, the same as go_repo does.
         visibility: Visibility for the install target.
         third_party_path: Where subrepos are placed. Defaults to the package
                           these declarations live in, which is what keeps
@@ -1470,7 +1473,14 @@ def rust_repo(
     tool_ref = _subrepo_ref(CONFIG.RUST.PLEASE_RUST_TOOL)
     rustc_ref = _subrepo_ref(CONFIG.RUST.RUSTC)
     sysroot_ref = _subrepo_ref(CONFIG.RUST.SYSROOT)
-    cmds = [
+    cmds = []
+    if patch:
+        # Before anything reads the tree: a patch can change Cargo.toml, and
+        # generation derives the whole build file from it. -p1 and the crate
+        # root as cwd, matching go_repo, so a patch made against the crate's
+        # own source applies unchanged.
+        cmds += ['for p in $SRCS_PATCH; do patch -d $SRCS_CRATE -p1 < "$TMP_DIR/$p"; done']
+    cmds += [
         # Remove any existing BUILD files or plzconfig
         "rm -rf $SRCS_CRATE/.plzconfig",
         # -type f so a crate shipping a build/ directory survives this on a
@@ -1486,6 +1496,8 @@ def rust_repo(
     srcs = {
         "crate": [download],
     }
+    if patch:
+        srcs["patch"] = patch
     if lock:
         srcs["lock"] = [lock]
 

--- a/test/patch/BUILD
+++ b/test/patch/BUILD
@@ -1,0 +1,39 @@
+subinclude("//build_defs:rust", "//build_defs:rust_repo")
+
+# rust_repo takes a `patch` argument, which was documented and consumed by
+# nothing: a consumer setting it got no patch applied and no error either.
+# The crate here returns the wrong answer until the patch is applied, so this
+# fails rather than passing quietly if that regresses.
+
+genrule(
+    name = "crate_src",
+    srcs = glob(["crate/**"]),
+    # Under a directory of its own, named for the crate and version, because
+    # rust_repo names its subrepo output after the rule.
+    outs = ["srcs/patched-0.1.0"],
+    cmd = "mkdir -p $(dirname $OUT) && mv $PKG_DIR/crate $OUT",
+)
+
+rust_repo(
+    name = "patched",
+    crate = "patched",
+    download = ":crate_src",
+    lock = ":patch_lock",
+    patch = ["fix.patch"],
+    third_party_path = "test/patch",
+    version = "0.1.0",
+)
+
+rust_resolve(
+    name = "patch_lock",
+    entries = [
+        "patched|patched|0.1.0||true|true",
+    ],
+)
+
+rust_test(
+    name = "patch_test",
+    root = "patch_test.rs",
+    edition = "2021",
+    deps = [":patched"],
+)

--- a/test/patch/crate/Cargo.toml
+++ b/test/patch/crate/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "patched"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "patched"
+path = "src/lib.rs"

--- a/test/patch/crate/src/lib.rs
+++ b/test/patch/crate/src/lib.rs
@@ -1,0 +1,5 @@
+//! The unpatched crate is deliberately wrong, so a patch that does not apply
+//! shows up as a failing test rather than as a silently unchanged build.
+pub fn answer() -> u32 {
+    41
+}

--- a/test/patch/fix.patch
+++ b/test/patch/fix.patch
@@ -1,0 +1,9 @@
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,5 +1,5 @@
+ //! The unpatched crate is deliberately wrong, so a patch that does not apply
+ //! shows up as a failing test rather than as a silently unchanged build.
+ pub fn answer() -> u32 {
+-    41
++    42
+ }

--- a/test/patch/patch_test.rs
+++ b/test/patch/patch_test.rs
@@ -1,0 +1,12 @@
+//! `rust_repo(patch = ...)` was declared and documented for the life of the
+//! plugin and consumed by nothing, so a consumer setting it got no patch and
+//! no error. This fails if the patch is not applied.
+
+#[test]
+fn the_patch_is_applied() {
+    assert_eq!(
+        patched::answer(),
+        42,
+        "rust_repo(patch = ...) did not apply the patch"
+    );
+}


### PR DESCRIPTION
Closes #17.

## What was wrong

`patch` was declared on `rust_repo` and consumed by nothing. It appeared exactly twice in the repository, in the parameter list and in its own docstring, so a consumer writing `patch = ["fix.patch"]` got no patch applied and no error either. A documented no-op, which is worse than an untested feature: it looks like it works.

## Why implement rather than delete

#17 offered proving it or removing it, and removing looked right until the demand turned out to be real. go-rules implements `patch` on `go_repo`, and labs uses it three times today, on gopsutil, kolla and otel. A team already patching three Go modules will want it for a crate eventually, and go-rules does it in two lines, so implementing costs about what deleting would have.

## How

The same shape as `go_repo`. Patch files become srcs of the rule that owns the unpacked tree, and `patch -p1` runs from the crate root.

**Ordering is deliberate.** Generation derives the entire build file from `Cargo.toml`, so a patch that touches the manifest has to land before `generate` runs rather than after it.

## Test

`test/patch`, built the way `test/firstparty` builds a local crate, so it needs no network. The crate returns 41 until patched and the test asserts 42, so a patch that fails to apply is a failing assertion rather than a quietly unchanged build.

**Verified red then green**: with the argument returned to a no-op the test fails with `rust_repo(patch = ...) did not apply the patch`; with the fix it passes.

## Checks

180 tests green, clippy clean, and the CI steps run locally before committing: build everything, run tests, discovery script parses, project file generation.