### PR TITLE
Name a crate the way source imports it

### DIFF
--- a/build_defs/rust.build_defs
+++ b/build_defs/rust.build_defs
@@ -514,7 +514,14 @@ def _ide_fragment(name:str, crate_name:str, root:str, edition:str, features:list
     build never runs one.
     """
     pkg = package_name()
-    root_path = pkg + '/' + root if pkg else root
+    # A root can be a label rather than a file: a crate whose root module is
+    # generated, which is every crate the proto rules produce. Joining a label
+    # to the package gives service/:_widget_proto#mod_rs, which is not a path
+    # and which nothing can open. plz knows where it put the file, so ask.
+    if root.startswith(':') or root.startswith('//'):
+        root_path = '$(out_location %s)' % root
+    else:
+        root_path = pkg + '/' + root if pkg else root
     dep_json = ', '.join(['{"name": "%s", "label": "%s"}' % (
         canonicalise(d).split(':')[-1].replace('-', '_'), canonicalise(d)) for d in deps])
     feature_json = ', '.join(['"%s"' % f for f in (features or [])])

--- a/test/genroot/BUILD
+++ b/test/genroot/BUILD
@@ -1,0 +1,22 @@
+subinclude("//build_defs:rust")
+
+# A crate whose root module is generated rather than checked in. The IDE
+# fragment used to record the label it was given, joined to the package, so
+# the project file named a path no build could produce.
+genrule(
+    name = "generated_src",
+    outs = ["generated.rs"],
+    cmd = 'echo "pub fn answer() -> u32 { 42 }" > $OUT',
+)
+
+rust_library(
+    name = "genroot",
+    root = ":generated_src",
+    visibility = ["PUBLIC"],
+)
+
+rust_test(
+    name = "genroot_test",
+    root = "genroot_test.rs",
+    deps = [":genroot"],
+)

--- a/test/genroot/genroot_test.rs
+++ b/test/genroot/genroot_test.rs
@@ -1,0 +1,8 @@
+// The crate this depends on has a generated root module, which is the shape
+// the IDE fragment used to record as a label rather than a path.
+extern crate genroot;
+
+#[test]
+fn a_crate_rooted_at_a_generated_file_builds() {
+    assert_eq!(genroot::answer(), 42);
+}

--- a/tools/please_rust/src/ide.rs
+++ b/tools/please_rust/src/ide.rs
@@ -603,13 +603,20 @@ fn describe_project(args: IdeArgs) -> Result<()> {
         .map(|(i, (k, _))| (k.clone(), i + offset))
         .collect();
 
+    // What each crate is imported by, so a dep can be named the way the
+    // depending source writes it rather than the way the package is named.
+    let idents: BTreeMap<Key, String> = order
+        .iter()
+        .map(|(k, e)| (k.clone(), ident_of(e)))
+        .collect();
+
     // Pass two: describe each one.
     let mut skipped = Vec::new();
     // What the project will point at, and which crate has to be built for it
     // to be there.
     let mut inputs: Vec<(String, String)> = Vec::new();
     for ((subrepo, _host), entry) in &order {
-        match describe(&args.third_party_dir, subrepo, entry, &index) {
+        match describe(&args.third_party_dir, subrepo, entry, &index, &idents) {
             Ok(c) => {
                 inputs.push((subrepo.clone(), c.root_module.clone()));
                 if let Some(dylib) = &c.proc_macro_dylib_path {
@@ -662,9 +669,16 @@ fn describe_project(args: IdeArgs) -> Result<()> {
     // Keyed by label, and scoped: a subrepo's labels are relative to itself,
     // so `//foo:bar` there and `//foo:bar` here are different crates.
     let mut by_label: BTreeMap<(String, String), usize> = BTreeMap::new();
+    // What each one is imported by, for the same reason as the third-party
+    // idents: a label names a build target and source names a crate.
+    let mut ident_by_label: BTreeMap<(String, String), String> = BTreeMap::new();
     for (i, (_, fp, scope)) in first.iter().enumerate() {
         if !fp.label.is_empty() {
             by_label.insert((scope.clone(), fp.label.clone()), crates.len() + i);
+            ident_by_label.insert(
+                (scope.clone(), fp.label.clone()),
+                fp.display_name.replace('-', "_"),
+            );
         }
     }
     // A dep that resolves to nothing is dropped, and the only symptom is an
@@ -677,6 +691,13 @@ fn describe_project(args: IdeArgs) -> Result<()> {
             // A first-party dep names another fragment in the same repo;
             // anything else is a declaration in the lock.
             if let Some(i) = by_label.get(&(scope.clone(), d.label.clone())) {
+                // The dep's own name, not the label's. A generated proto
+                // crate is built by a target called _widget_proto#rust and
+                // imported as widget_proto.
+                let name = ident_by_label
+                    .get(&(scope.clone(), d.label.clone()))
+                    .cloned()
+                    .unwrap_or(name);
                 deps.push(DepEntry { krate: *i, name });
             } else if let Some(i) = label_subrepo(&d.label).and_then(|s| index.get(&(s, false))) {
                 // The crate's own name rather than the label's: a label
@@ -789,7 +810,7 @@ fn describe_project(args: IdeArgs) -> Result<()> {
 /// left of where they should.
 fn placeholder(entry: &crate::resolve::LockEntry) -> CrateEntry {
     CrateEntry {
-        display_name: entry.crate_name.replace('-', "_"),
+        display_name: ident_of(entry),
         root_module: String::new(),
         edition: "2021".to_string(),
         deps: Vec::new(),
@@ -807,6 +828,7 @@ fn describe(
     subrepo: &str,
     entry: &crate::resolve::LockEntry,
     index: &BTreeMap<Key, usize>,
+    idents: &BTreeMap<Key, String>,
 ) -> Result<CrateEntry> {
     // Everything but the build-script cfgs comes from the lock, so this works
     // inside a build sandbox where the crate sources are not staged. Reading
@@ -819,9 +841,7 @@ fn describe(
     let dir = third_party.join(subrepo);
     let root = dir.join(&entry.root_module);
 
-    // The crate name is what source imports, which is not the package name
-    // whenever a manifest sets [lib] name.
-    let ident = entry.crate_name.replace('-', "_");
+    let ident = ident_of(entry);
 
     let mut cfg: Vec<String> = entry
         .features
@@ -835,11 +855,20 @@ fn describe(
     let mut deps = Vec::new();
     for d in &entry.deps {
         let is_host = d.target_name.ends_with("_host");
-        if let Some(i) = index.get(&(d.subrepo.clone(), is_host)) {
-            deps.push(DepEntry {
-                krate: *i,
-                name: d.name.replace('-', "_"),
-            });
+        let key = (d.subrepo.clone(), is_host);
+        if let Some(i) = index.get(&key) {
+            // A dependent that renamed the crate writes the rename, and one
+            // that did not writes the crate's own name. Neither is the
+            // package name whenever a manifest sets [lib] name: the package
+            // sha-1 builds sha1, and `extern crate sha1` finds nothing if the
+            // dep is recorded as sha_1.
+            let declared = d.name.replace('-', "_");
+            let name = if declared != d.crate_name.replace('-', "_") {
+                declared
+            } else {
+                idents.get(&key).cloned().unwrap_or(declared)
+            };
+            deps.push(DepEntry { krate: *i, name });
         }
     }
 
@@ -907,6 +936,18 @@ fn describe(
 /// a crate that analyses and one that is half red. libc alone sets dozens.
 /// Already parsed and written next to the crate by `build-script`, so this
 /// reads rather than recomputes.
+/// The name source imports the crate by, which is the `[lib] name` when a
+/// manifest sets one and the package name otherwise. The compile path makes
+/// the same choice in generate.rs; these two disagreeing is what makes a
+/// crate build and not resolve.
+fn ident_of(entry: &crate::resolve::LockEntry) -> String {
+    if entry.lib_name.is_empty() {
+        entry.crate_name.replace('-', "_")
+    } else {
+        entry.lib_name.replace('-', "_")
+    }
+}
+
 fn buildscript_cfgs(dir: &Path) -> Vec<String> {
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -1271,5 +1312,46 @@ rustc-cfg=fake
         let p = placeholder(&entry);
         assert_eq!(p.display_name, "broken_crate");
         assert!(p.root_module.is_empty());
+    }
+
+    /// A manifest that sets `[lib] name` renames the crate without renaming
+    /// the package, and source imports the lib name. The compile path has
+    /// always known this; the project file did not, so `extern crate sha1`
+    /// against the package sha-1 built and did not resolve.
+    #[test]
+    fn a_crate_is_named_the_way_source_imports_it() {
+        let package_only = crate::resolve::LockEntry {
+            crate_name: "sha-1".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(ident_of(&package_only), "sha_1");
+
+        let with_lib = crate::resolve::LockEntry {
+            crate_name: "sha-1".to_string(),
+            lib_name: "sha1".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(ident_of(&with_lib), "sha1");
+        assert_eq!(placeholder(&with_lib).display_name, "sha1");
+
+        // rustls-webpki builds webpki, and md-5 builds md5.
+        for (package, lib, want) in [
+            ("rustls-webpki", "webpki", "webpki"),
+            ("md-5", "md5", "md5"),
+            (
+                "new_debug_unreachable",
+                "debug_unreachable",
+                "debug_unreachable",
+            ),
+            // The overwhelming majority: no [lib] name, so nothing recorded.
+            ("serde", "", "serde"),
+        ] {
+            let e = crate::resolve::LockEntry {
+                crate_name: package.to_string(),
+                lib_name: lib.to_string(),
+                ..Default::default()
+            };
+            assert_eq!(ident_of(&e), want, "{}", package);
+        }
     }
 }

--- a/tools/please_rust/src/resolve.rs
+++ b/tools/please_rust/src/resolve.rs
@@ -85,6 +85,13 @@ pub struct LockEntry {
     pub edition: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub root_module: String,
+    /// The name the crate is imported by, when a manifest sets `[lib] name`
+    /// and it differs from the package. Recorded for the same reason as
+    /// `root_module`: generating a rust-project.json has the lock and nothing
+    /// else, and a dependent writing `use md5::` finds nothing if the package
+    /// name md-5 is used instead. Empty means the two agree.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub lib_name: String,
     /// A proc macro is a different kind of crate to rust-analyzer, and
     /// resolution already knows because it decides the host unit by it.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -846,6 +853,16 @@ fn emit_entry(
             .and_then(|l| l.path.clone())
             .or_else(|| n.manifest.bin.iter().find_map(|b| b.path.clone()))
             .unwrap_or_else(|| "src/lib.rs".to_string()),
+        // Only when it says something the crate name does not, so a lock is
+        // unchanged for the crates where the two agree, which is almost all
+        // of them.
+        lib_name: n
+            .manifest
+            .lib
+            .as_ref()
+            .and_then(|l| l.name.clone())
+            .filter(|l| *l != n.crate_name.replace('-', "_"))
+            .unwrap_or_default(),
         is_proc_macro: n.is_proc_macro,
         // Set by the caller, which is what knows whether this is the entry's
         // primary unit or its _host twin.


### PR DESCRIPTION
Closes #43. Found by bumping rust-corpus to `e715d03` and running rust-analyzer over it.

**rust-corpus, 1,373 crates: 11 diagnostics to 0.**

## Two places recorded a build target where a crate name belongs

rust-analyzer resolves `extern crate foo` and `use foo::` against a dep's name, so that name has to be the one the source writes.

### `[lib] name`

A manifest that sets `[lib] name` renames the crate without renaming the package. The compile path has always known this, and says so in `generate.rs`:

```rust
// Cargo names the crate after [lib] name when it is set, not after the
// package: md-5 builds a crate called md5, and a dependent writing
// `use md5::...` finds nothing if the package name is used instead.
```

The IDE path works from the lock alone, deliberately, because the crate sources live in `plz-out` and a build rule cannot see them. The lock did not carry the lib name, so it used the package. Five crates in rust-corpus:

| target | lib name |
|---|---|
| `md_5` | `md5` |
| `new_debug_unreachable` | `debug_unreachable` |
| `rust_ini` | `ini` |
| `rustls_webpki` | `webpki` |
| `sha_1` | `sha1` |

`sha_1` was the worst shape: an unrelated crate genuinely named `sha1` is also in that graph, so the wrong name collided with a real entry rather than simply missing.

`LockEntry` now records `lib_name`, the same way it already records `edition` and `root_module` and for the same reason. It is written only when it differs from the package, so locks are unchanged for the crates where the two agree, which is nearly all of them.

### A root that is a label

A crate's root can be a generated file, which is every crate the proto rules produce. The fragment joined the label to its package and recorded:

```
service/:_widget_proto#mod_rs
```

That is not a path. plz knows where it put the file, so ask it with `$(out_location)`. Confirmed `$(location)` gives `test/genroot/generated.rs`, which does not exist, and `$(out_location)` gives `plz-out/gen/test/genroot/generated.rs`, which does.

A declared rename still wins in both cases, since a rename is what the source writes.

## Why CI missed it

rust-rules has no crate with a `[lib] name` mismatch and no crate rooted at a generated file, so neither shape existed here to fail on.

`test/genroot` adds the second one: a crate rooted at a genrule output, reproduced red before the fix (`"root_module": "test/genroot/:generated_src"`). CI already asserts every `root_module` exists, so that assertion now covers this shape permanently.

## Verification

- rust-corpus: 11 diagnostics to 0, and no crate of 1,373 has a `root_module` that does not exist
- rust-rules: still 222 crates, and exactly one dep name differs from the crate it points at, `rand`'s `getrandom_package`, which is a real `package = "getrandom"` rename and correct
- 183 tests pass, clippy clean, fmt clean