### PR TITLE
Describe every lock in the repo, not just one

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -80,8 +80,15 @@ jobs:
 
       - name: Generate the rust-analyzer project file
         run: |
-          ./pleasew run -p -v notice //:rust-project
+          ./pleasew run -p -v notice //:rust-project 2>&1 | tee /tmp/project.log
           test -f rust-project.json || { echo "no rust-project.json"; exit 1; }
+          # A dep in a package no lock covers resolves to nothing in the
+          # editor, and this repo has four rust_resolve targets.
+          if grep -q "in no lock" /tmp/project.log; then
+            echo "a dep is outside every lock passed to rust_project:"
+            grep "in no lock" /tmp/project.log
+            exit 1
+          fi
           python3 - <<'PY'
           import json, os, sys
           d = json.load(open("rust-project.json"))

--- a/BUILD
+++ b/BUILD
@@ -19,5 +19,13 @@ filegroup(
 # root. Nothing to keep in step: a crate added anywhere is in the next run.
 rust_project(
     name = "rust-project",
-    lock = "//third_party/crates:rust_lock",
+    # Every rust_resolve in the repo. The test packages declare their own so
+    # that what they are testing is isolated, and a crate that depends on one
+    # of those resolves in the editor only if its lock is here too.
+    lock = [
+        "//third_party/crates:rust_lock",
+        "//test/firstparty:firstparty_lock",
+        "//test/links:links_lock",
+        "//test/patch:patch_lock",
+    ],
 )

--- a/README.md
+++ b/README.md
@@ -519,10 +519,26 @@ rust_project(
 also declare several of these, one per subtree, each with its own `out`. Only
 the file at the repo root is the one an editor will find.
 
+A repo that declares third-party crates in more than one place passes every
+lock:
+
+```python
+rust_project(
+    name = "rust-project",
+    lock = [
+        "//third_party/crates:rust_lock",
+        "//services/payments/third_party:payments_lock",
+    ],
+)
+```
+
+Each lock's crates are found under the package that declares them. A crate
+depending on a lock that was left out is reported by name.
+
 #### When something does not resolve
 - **A third-party crate's imports do not resolve.** Its declaration is in a
   lock this project file was not given. The run names the crate and the
-  dependency.
+  dependency. Add that `rust_resolve` target to `lock`.
 - **A crate's `#[cfg(...)]` items look inactive.** Build-script cfgs come from
   what the build has produced. It corrects itself as you build.
 - **Nothing resolves, including `std`.** Set `rust_toolchain(src_hash = ...)`

--- a/build_defs/rust.build_defs
+++ b/build_defs/rust.build_defs
@@ -555,7 +555,7 @@ def _sq(value:str):
     return "'" + value.replace("'", "'\\''") + "'"
 
 
-def rust_project(name:str, lock:str='', targets:list=['//...'], exclude:list=[], subrepos:list=[],
+def rust_project(name:str, lock='', targets:list=['//...'], exclude:list=[], subrepos:list=[],
                  third_party_dir:str='plz-out/gen/third_party/crates',
                  sysroot:str='', sysroot_src:str='',
                  out:str='rust-project.json', visibility:list=None):
@@ -577,8 +577,10 @@ def rust_project(name:str, lock:str='', targets:list=['//...'], exclude:list=[],
 
     Args:
         name (str): Name of the rule.
-        lock (str): The rust_resolve target whose lock describes third-party
-                    crates. Without one only first-party crates are emitted.
+        lock (str | list): The rust_resolve target whose lock describes
+                    third-party crates, or a list of them when a repo declares
+                    crates in more than one place. Without one only
+                    first-party crates are emitted.
         targets (list): Where to look for crates. The default covers the whole
                         repo, which is what a repo of one project wants. A
                         monorepo with Rust in one subtree can narrow it to
@@ -592,7 +594,10 @@ def rust_project(name:str, lock:str='', targets:list=['//...'], exclude:list=[],
                          e.g. a shared crate from a github_repo. Crates found
                          in a subrepo are described but never checked on
                          save: a subrepo is checked in its own repo.
-        third_party_dir (str): Where the generated crate subrepos land.
+        third_party_dir (str): Where the generated crate subrepos land. Used
+                               only with a single lock; with several, each
+                               lock's directory follows the package that
+                               declares its crates.
         sysroot (str): A rustup-shaped toolchain root - `bin/rustc` beside
                        `lib/rustlib`. That is the rustc component, and
                        deliberately not what `Sysroot` names: rust-analyzer
@@ -612,7 +617,8 @@ def rust_project(name:str, lock:str='', targets:list=['//...'], exclude:list=[],
     # the plugin is its own repo); canonicalise gives the label back in the
     # form a command line takes.
     tool = canonicalise(CONFIG.RUST.PLEASE_RUST_TOOL)
-    lock = canonicalise(lock) if lock else ''
+    locks = [lock] if isinstance(lock, str) else lock
+    locks = [canonicalise(l) for l in locks if l]
     # Where the toolchain lands is the toolchain's business, and it moves with
     # whoever declares it: in a consumer it is under the plugin's subrepo, not
     # this repo's third_party. Ask plz at run time rather than write a path
@@ -630,11 +636,11 @@ def rust_project(name:str, lock:str='', targets:list=['//...'], exclude:list=[],
         '#!/bin/sh',
         'NAME=%s' % _sq(name),
         'TOOL_LABEL=%s' % _sq(tool),
-        'LOCK_LABEL=%s' % _sq(lock),
+        'LOCK_LABELS=%s' % _sq(' '.join(locks)),
         'TARGETS=%s' % _sq(' '.join(targets)),
         'EXCLUDES=%s' % _sq(' '.join(exclude)),
         'SUBREPOS=%s' % _sq(' '.join(subrepos)),
-        'THIRD_PARTY_DIR=%s' % _sq(third_party_dir),
+        'THIRD_PARTY_DIR=%s' % _sq(third_party_dir if len(locks) < 2 else ''),
         'SYSROOT=%s' % _sq(sysroot),
         'SYSROOT_SRC=%s' % _sq(sysroot_src),
         'SYSROOT_TARGET=%s' % _sq('' if sysroot else rustc_target),

--- a/build_defs/rust_project.sh
+++ b/build_defs/rust_project.sh
@@ -3,7 +3,7 @@
 # repo and in the subrepos it pulls in, and describe them for rust-analyzer.
 #
 # The rule prepends a prelude setting NAME, TOOL_LABEL, TARGETS, EXCLUDES,
-# SUBREPOS, LOCK_LABEL, THIRD_PARTY_DIR, SYSROOT, SYSROOT_SRC and OUT_FILE.
+# SUBREPOS, LOCK_LABELS, THIRD_PARTY_DIR, SYSROOT, SYSROOT_SRC and OUT_FILE.
 # Values are never substituted into the shell text, so no path or label can be
 # read as syntax.
 set -eu
@@ -161,7 +161,7 @@ fi
 say "describing `echo $FRAGS | wc -w` crates"
 # The toolchain too: resolving where it lands is not the same as it being
 # there, and a sysroot_src that was never built is a std with no sources.
-"$PLZ" build $TOOL_LABEL $LOCK_LABEL $SYSROOT_TARGET $SYSROOT_SRC_TARGET $FRAGS >/dev/null
+"$PLZ" build $TOOL_LABEL $LOCK_LABELS $SYSROOT_TARGET $SYSROOT_SRC_TARGET $FRAGS >/dev/null
 TOOL=`"$PLZ" query outputs $TOOL_LABEL`
 # The toolchain is wherever whoever declared it put it, so ask rather than
 # assume. An explicit sysroot in the rule wins and skips this.
@@ -174,10 +174,22 @@ fi
 if [ -z "$SYSROOT" ]; then
     echo "$NAME: could not locate the toolchain, so rust-analyzer will have no std" >&2
 fi
+# One --lock per rust_resolve. Each carries the package its crates are
+# declared in, so a dep's label picks the right lock, and where that lock's
+# subrepos land. A repo with one lock and an explicit third_party_dir keeps
+# using it.
 LOCK_ARG=""
-if [ -n "$LOCK_LABEL" ]; then
-    LOCK_ARG="--lock `"$PLZ" query outputs $LOCK_LABEL`"
-fi
+LOCK_N=`echo $LOCK_LABELS | wc -w`
+for label in $LOCK_LABELS; do
+    pkg=${label%:*}
+    pkg=${pkg#//}
+    if [ "$LOCK_N" = 1 ] && [ -n "$THIRD_PARTY_DIR" ]; then
+        dir=$THIRD_PARTY_DIR
+    else
+        dir=plz-out/gen/$pkg
+    fi
+    LOCK_ARG="$LOCK_ARG --lock $pkg=$dir=`"$PLZ" query outputs $label`"
+done
 FILES=`"$PLZ" query outputs $FRAGS`
 
 # Subrepos. Plugin ones plz already lists, so they need no naming; anything
@@ -249,17 +261,16 @@ done < "$WORK/skipped"
 # its sources, the lock, the proc-macro dylibs - so it is not a list any more.
 # The tool says what it will point at; anything missing gets built, whatever
 # kind of thing it is.
-if [ -n "$LOCK_LABEL" ]; then
-    LOCK_PKG=${LOCK_LABEL%:*}
+if [ -n "$LOCK_LABELS" ]; then
     # shellcheck disable=SC2086
-    "$TOOL" ide $LOCK_ARG --third-party-dir $THIRD_PARTY_DIR --sysroot $SYSROOT \
+    "$TOOL" ide $LOCK_ARG --sysroot $SYSROOT \
         --sysroot-src $SYSROOT_SRC --first-party $FILES $SUBARGS \
         --emit-inputs "$WORK/inputs" --output "$WORK/scratch.json" >/dev/null 2>&1 || \
         : > "$WORK/inputs"
     : > "$WORK/missing"
     while IFS="	" read -r subrepo file; do
         if [ -n "$file" ] && [ ! -e "$file" ]; then
-            echo "$LOCK_PKG:$subrepo" >> "$WORK/missing"
+            echo "$subrepo" >> "$WORK/missing"
         fi
     done < "$WORK/inputs"
     if [ -s "$WORK/missing" ]; then
@@ -286,7 +297,7 @@ else
     OUT_ARG="--output $OUT_FILE"
 fi
 # shellcheck disable=SC2086
-"$TOOL" ide $LOCK_ARG --third-party-dir $THIRD_PARTY_DIR --sysroot $SYSROOT \
+"$TOOL" ide $LOCK_ARG --sysroot $SYSROOT \
     --sysroot-src $SYSROOT_SRC --first-party $FILES $SUBARGS $OUT_ARG
 
 if [ "$DISCOVER" = 0 ]; then

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -45,8 +45,7 @@ rather than by release:
 - **Believed to work, never demonstrated:**
   [#14](https://github.com/becomeliminal/rust-rules/issues/14) remote execution paths,
   [#15](https://github.com/becomeliminal/rust-rules/issues/15) remote execution audit,
-  [#16](https://github.com/becomeliminal/rust-rules/issues/16) musl and embedded,
-  [#17](https://github.com/becomeliminal/rust-rules/issues/17) the patches argument
+  [#16](https://github.com/becomeliminal/rust-rules/issues/16) musl and embedded
 - **Missing capability:**
   [#21](https://github.com/becomeliminal/rust-rules/issues/21) git forges,
   [#22](https://github.com/becomeliminal/rust-rules/issues/22) sync --upgrade,
@@ -58,8 +57,7 @@ rather than by release:
   [#28](https://github.com/becomeliminal/rust-rules/issues/28) bench profile,
   [#29](https://github.com/becomeliminal/rust-rules/issues/29) per-package profiles
 - **Editor gaps inside a shipped feature:**
-  [#19](https://github.com/becomeliminal/rust-rules/issues/19) generated sources,
-  [#20](https://github.com/becomeliminal/rust-rules/issues/20) one lock per project
+  [#42](https://github.com/becomeliminal/rust-rules/issues/42) a module naming a build output
 - **Evidence:**
   [#30](https://github.com/becomeliminal/rust-rules/issues/30) four-way corpus,
   [#31](https://github.com/becomeliminal/rust-rules/issues/31) corpus in CI,
@@ -86,7 +84,7 @@ rather than by release:
 | **Import an existing Cargo.lock**<br>Adopting a repo that already uses cargo | **yes**. sync --import, and --import-workspace for BUILD files too | **yes**. crate_universe consumes Cargo.toml directly | **yes**. Native |
 | **Git and fork dependencies**<br>Pinned revision instead of crates.io | **partial**. github archive URLs; other forges need download= | **yes**. Supported | **yes**. Native |
 | **Private or alternative registries**<br>Registry auth | **no**. On demand only; forks and download= cover the cases | **yes**. Via cargo | **yes**. Native |
-| **Vendored source overrides**<br>Patch or replace a crate's source | **partial**. download= overrides; patches arg exists, unexercised | **yes**. annotations and patches | **yes**. [patch] and [replace] |
+| **Vendored source overrides**<br>Patch or replace a crate's source | **yes**. download= overrides the source, patch= applies patches to it | **yes**. annotations and patches | **yes**. [patch] and [replace] |
 
 ## The Cargo build contract
 

--- a/tools/please_rust/src/ide.rs
+++ b/tools/please_rust/src/ide.rs
@@ -18,12 +18,21 @@ use std::path::{Path, PathBuf};
 
 #[derive(Args)]
 pub struct IdeArgs {
-    /// The resolved lock, as `rust_resolve` produces it
+    /// A resolved lock, as `rust_resolve` produces it. Repeatable, because a
+    /// repo can declare third-party crates in more than one place and each
+    /// `rust_resolve` produces its own lock.
+    ///
+    /// Two forms. `<package>=<third_party_dir>=<path>` says which build
+    /// package the lock's crates are declared in, which is how a dep's label
+    /// picks the lock it belongs to, and where that lock's subrepos are
+    /// checked out. A bare `<path>` is the old single-lock form and pairs
+    /// with `--third-party-dir`.
     #[arg(long)]
-    pub lock: PathBuf,
+    pub lock: Vec<String>,
 
-    /// Directory holding the generated crate subrepos, one per declaration
-    #[arg(long)]
+    /// Directory holding the generated crate subrepos, one per declaration.
+    /// Applies to a `--lock` given in the bare form.
+    #[arg(long, default_value = "plz-out/gen/third_party/crates")]
     pub third_party_dir: PathBuf,
 
     /// A rustup-shaped toolchain root: `bin/rustc` beside `lib/rustlib`.
@@ -133,6 +142,13 @@ struct FirstPartyDep {
 /// is the subrepo `serde`, which is how the lock keys it.
 fn label_subrepo(label: &str) -> Option<String> {
     label.rsplit(':').next().map(|t| t.to_string())
+}
+
+/// The build package a label names, without the leading slashes or the
+/// target: `//third_party/crates:serde` is declared in `third_party/crates`.
+fn label_package(label: &str) -> String {
+    let body = label.split_once(':').map(|(p, _)| p).unwrap_or(label);
+    body.trim_start_matches('/').to_string()
 }
 
 #[derive(Serialize)]
@@ -456,7 +472,51 @@ fn expand_features(
 /// A crate's identity in the lock: its subrepo, and which unit of it. The
 /// host unit of a dual crate is a different crate to rust-analyzer - it is
 /// compiled for a different platform and may have different features.
-type Key = (String, bool);
+/// A crate's identity across every lock: which lock it came from, its
+/// subrepo, and which unit of it. The lock is part of the key because two
+/// locks can each hold a `serde` and they are different crates.
+type Key = (usize, String, bool);
+
+/// One lock, and what is needed to place the crates in it.
+struct LockSource {
+    /// The build package its crates are declared in, e.g. `third_party/crates`.
+    /// A first-party dep names `//third_party/crates:serde`, and this is how
+    /// that label finds its lock.
+    package: String,
+    /// Where this lock's subrepos are checked out.
+    third_party_dir: PathBuf,
+    lock: crate::resolve::LockFile,
+}
+
+/// Which lock a dep's label belongs to, by the package its crates are
+/// declared in. A lock given in the bare form has no package recorded and
+/// matches anything, which is what a single-lock repo has always done.
+fn lock_for_label(sources: &[LockSource], label: &str) -> Option<usize> {
+    let pkg = label_package(label);
+    sources
+        .iter()
+        .position(|s| s.package == pkg)
+        .or_else(|| sources.iter().position(|s| s.package.is_empty()))
+}
+
+/// Parse a `--lock` value. `<package>=<dir>=<path>`, or a bare path paired
+/// with `--third-party-dir`.
+fn parse_lock_spec(spec: &str, fallback_dir: &Path) -> (String, PathBuf, PathBuf) {
+    let parts: Vec<&str> = spec.splitn(3, '=').collect();
+    if parts.len() == 3 {
+        (
+            parts[0].to_string(),
+            PathBuf::from(parts[1]),
+            PathBuf::from(parts[2]),
+        )
+    } else {
+        (
+            String::new(),
+            fallback_dir.to_path_buf(),
+            PathBuf::from(spec),
+        )
+    }
+}
 
 /// rust-analyzer panics rather than errors on a relative buildfile, so no
 /// caller gets to pass one.
@@ -542,8 +602,17 @@ pub fn run(args: IdeArgs) -> Result<()> {
 }
 
 fn describe_project(args: IdeArgs) -> Result<()> {
-    let lock = crate::resolve::LockFile::load(&args.lock)
-        .with_context(|| format!("reading {}", args.lock.display()))?;
+    let mut sources: Vec<LockSource> = Vec::new();
+    for spec in &args.lock {
+        let (package, third_party_dir, path) = parse_lock_spec(spec, &args.third_party_dir);
+        let lock = crate::resolve::LockFile::load(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        sources.push(LockSource {
+            package,
+            third_party_dir,
+            lock,
+        });
+    }
 
     // The sysroot is described as a nested project rather than as crates in
     // the main list, so rust-analyzer registers it as the sysroot and its
@@ -591,11 +660,13 @@ fn describe_project(args: IdeArgs) -> Result<()> {
 
     // Pass one: assign an index to every crate, so deps can name them.
     let mut order: Vec<(Key, &crate::resolve::LockEntry)> = Vec::new();
-    for (subrepo, entry) in &lock.crates {
-        order.push(((subrepo.clone(), false), entry));
-    }
-    for (subrepo, entry) in &lock.host_crates {
-        order.push(((subrepo.clone(), true), entry));
+    for (li, src) in sources.iter().enumerate() {
+        for (subrepo, entry) in &src.lock.crates {
+            order.push(((li, subrepo.clone(), false), entry));
+        }
+        for (subrepo, entry) in &src.lock.host_crates {
+            order.push(((li, subrepo.clone(), true), entry));
+        }
     }
     let index: BTreeMap<Key, usize> = order
         .iter()
@@ -615,12 +686,26 @@ fn describe_project(args: IdeArgs) -> Result<()> {
     // What the project will point at, and which crate has to be built for it
     // to be there.
     let mut inputs: Vec<(String, String)> = Vec::new();
-    for ((subrepo, _host), entry) in &order {
-        match describe(&args.third_party_dir, subrepo, entry, &index, &idents) {
+    for ((li, subrepo, _host), entry) in &order {
+        match describe(
+            &sources[*li].third_party_dir,
+            *li,
+            subrepo,
+            entry,
+            &index,
+            &idents,
+        ) {
             Ok(c) => {
-                inputs.push((subrepo.clone(), c.root_module.clone()));
+                // The buildable label, because with more than one lock a
+                // subrepo name does not say which package declares it.
+                let target = if sources[*li].package.is_empty() {
+                    subrepo.clone()
+                } else {
+                    format!("//{}:{}", sources[*li].package, subrepo)
+                };
+                inputs.push((target.clone(), c.root_module.clone()));
                 if let Some(dylib) = &c.proc_macro_dylib_path {
-                    inputs.push((subrepo.clone(), dylib.clone()));
+                    inputs.push((target, dylib.clone()));
                 }
                 crates.push(c)
             }
@@ -699,7 +784,10 @@ fn describe_project(args: IdeArgs) -> Result<()> {
                     .cloned()
                     .unwrap_or(name);
                 deps.push(DepEntry { krate: *i, name });
-            } else if let Some(i) = label_subrepo(&d.label).and_then(|s| index.get(&(s, false))) {
+            } else if let Some(i) = lock_for_label(&sources, &d.label)
+                .zip(label_subrepo(&d.label))
+                .and_then(|(li, s)| index.get(&(li, s, false)))
+            {
                 // The crate's own name rather than the label's: a label
                 // carries the package, and rustls-webpki builds webpki.
                 let resolved = crates[*i].display_name.clone();
@@ -825,6 +913,7 @@ fn placeholder(entry: &crate::resolve::LockEntry) -> CrateEntry {
 
 fn describe(
     third_party: &Path,
+    lock_index: usize,
     subrepo: &str,
     entry: &crate::resolve::LockEntry,
     index: &BTreeMap<Key, usize>,
@@ -855,7 +944,9 @@ fn describe(
     let mut deps = Vec::new();
     for d in &entry.deps {
         let is_host = d.target_name.ends_with("_host");
-        let key = (d.subrepo.clone(), is_host);
+        // A lock's deps name subrepos in the same lock, so the crate is
+        // looked up in the lock it came from.
+        let key = (lock_index, d.subrepo.clone(), is_host);
         if let Some(i) = index.get(&key) {
             // A dependent that renamed the crate writes the rename, and one
             // that did not writes the crate's own name. Neither is the
@@ -1312,6 +1403,62 @@ rustc-cfg=fake
         let p = placeholder(&entry);
         assert_eq!(p.display_name, "broken_crate");
         assert!(p.root_module.is_empty());
+    }
+
+    /// A repo can declare third-party crates in more than one place, and each
+    /// rust_resolve produces its own lock. Two locks can hold a crate of the
+    /// same name, so a dep's label picks the lock by the package that
+    /// declares it.
+    #[test]
+    fn a_dep_finds_the_lock_its_package_declares() {
+        let (pkg, dir, path) = parse_lock_spec(
+            "test/patch=plz-out/gen/test/patch=/tmp/l.json",
+            Path::new("fb"),
+        );
+        assert_eq!(pkg, "test/patch");
+        assert_eq!(dir, PathBuf::from("plz-out/gen/test/patch"));
+        assert_eq!(path, PathBuf::from("/tmp/l.json"));
+
+        // The old single-lock form takes its directory from the flag.
+        let (pkg, dir, path) = parse_lock_spec("/tmp/only.json", Path::new("fallback/dir"));
+        assert!(pkg.is_empty());
+        assert_eq!(dir, PathBuf::from("fallback/dir"));
+        assert_eq!(path, PathBuf::from("/tmp/only.json"));
+
+        assert_eq!(
+            label_package("//third_party/crates:serde"),
+            "third_party/crates"
+        );
+        assert_eq!(label_package("//test/patch:patched"), "test/patch");
+
+        let sources = vec![
+            LockSource {
+                package: "third_party/crates".to_string(),
+                third_party_dir: PathBuf::from("plz-out/gen/third_party/crates"),
+                lock: Default::default(),
+            },
+            LockSource {
+                package: "test/patch".to_string(),
+                third_party_dir: PathBuf::from("plz-out/gen/test/patch"),
+                lock: Default::default(),
+            },
+        ];
+        assert_eq!(lock_for_label(&sources, "//test/patch:patched"), Some(1));
+        assert_eq!(
+            lock_for_label(&sources, "//third_party/crates:serde"),
+            Some(0)
+        );
+        // A dep in a package no lock declares belongs to no lock, which is
+        // what the warning is about.
+        assert_eq!(lock_for_label(&sources, "//elsewhere:thing"), None);
+
+        // One lock in the old form answers for everything, as it always has.
+        let legacy = vec![LockSource {
+            package: String::new(),
+            third_party_dir: PathBuf::from("plz-out/gen/third_party/crates"),
+            lock: Default::default(),
+        }];
+        assert_eq!(lock_for_label(&legacy, "//anywhere:thing"), Some(0));
     }
 
     /// A manifest that sets `[lib] name` renames the crate without renaming

--- a/tools/please_rust/src/resolve.rs
+++ b/tools/please_rust/src/resolve.rs
@@ -116,7 +116,7 @@ pub struct LockDep {
     pub target_name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct LockFile {
     pub target: String,
     /// Primary entry per subrepo (target unit; host unit if host-only)


### PR DESCRIPTION
Closes #20.

## What was wrong

`rust_project` took a single `lock`, so a repo declaring third-party crates in more than one place described only one of them. The rest surfaced one dep at a time:

```
ide: patch_test_test depends on //test/patch:patched, which is in no lock
     passed to --lock, imports from it will not resolve
```

**This repo has four `rust_resolve` targets and described one.** `//test/firstparty`, `//test/links` and `//test/patch` each declare their own so that what they test stays isolated, and every crate depending on them had unresolved imports in the editor.

## The change

`--lock` is repeatable, and each value carries what placing its crates needs:

```
--lock <package>=<third_party_dir>=<path>
```

The package is how a dep's label picks its lock, and it is the same thing that decides where the crate is checked out, so the two cannot drift apart.

A crate's key gains the lock it came from:

```rust
type Key = (usize, String, bool);
```

Two locks can each hold a `serde` and they are different crates. Without the lock in the key they would share an index and every dep after them would point at the wrong crate.

The bare `--lock <path>` form still works and still takes its directory from `--third-party-dir`, so a released tool paired with these rules behaves as before.

`rust_project(lock=)` now takes a string or a list.

## Result

The root `rust_project` names all four locks. **222 crates to 228**, no warnings, and every `root_module` exists. Each lock's crates land under the package that declares them:

```
renamed      plz-out/gen/test/firstparty/renamed_pkg/src/lib.rs
twin         plz-out/gen/test/firstparty/twin-0.2.0+spec-1.0/src/lib.rs
zconsumer    plz-out/gen/test/links/zconsumer/src/lib.rs
patched      plz-out/gen/test/patch/patched/src/lib.rs
```

`patch_test_test` now resolves `patched`, and `deps_test_test` resolves `renamed` and `twin`.

## Guard

CI fails if any dep is left outside every lock, rather than printing a warning nobody reads. That is what would have caught this repo's own four-lock case.

## Verification

- 184 tests pass, including a new one for lock selection by package, clippy clean, fmt clean
- the CI project-file assertions run locally: 228 crates, 26 first-party, 28 with OUT_DIR, no missing `root_module`
- `sh -n` on the discovery script