### PR TITLE
Say when an upgrade moved a version backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ A direct declaration keeps its compatibility range, so `0.4.1` reaches the
 newest `0.4.x` and does not cross to `0.5`. Indirect crates move when the
 crate that needs them asks for something newer. MSRV filtering still applies.
 
+A crate can move backwards, marked `v` rather than `^`. Taking the newest of
+one crate can cost another a version, because the newer release of that other
+crate forbade it.
+
 Version selection is a PubGrub solve over the crates.io index: it backtracks
 rather than failing when a late requirement rules out an earlier choice, and
 it respects `rust-version`, so an older `rust_toolchain` gets the newest

--- a/tools/please_rust/src/sync.rs
+++ b/tools/please_rust/src/sync.rs
@@ -1317,27 +1317,44 @@ fn parse_rust_version(s: &str) -> Option<Version> {
 fn report_upgrades(upgraded: &[(String, String, Version)], upgrading: bool) {
     use crate::pubgrub_solver::Bucket;
     const LIST_LIMIT: usize = 25;
+
+    // A version can move backwards during an upgrade, and it is not a bug.
+    // Taking the newest of one crate can mean stepping another back, because
+    // the newer release of that other crate forbade it: crypto-common 0.1.7
+    // requires generic-array =0.14.7, so reaching generic-array 0.14.9 costs
+    // crypto-common 0.1.6. Saying `^` about that is a lie, and a version
+    // going down is exactly the thing a reader needs to see.
+    let down = |from: &str, to: &Version| Version::parse(from).map(|f| f > *to).unwrap_or(false);
+    let mark = |from: &str, to: &Version| if down(from, to) { "v" } else { "^" };
+
     if !upgrading || upgraded.len() <= LIST_LIMIT {
         for (name, from, to) in upgraded {
-            eprintln!("lock: ^ {} {} -> {}", name, from, to);
+            eprintln!("lock: {} {} {} -> {}", mark(from, to), name, from, to);
         }
         return;
     }
-    let major: Vec<&(String, String, Version)> = upgraded
+
+    // Past the limit, the list is not read. What is worth saying is how many
+    // moved, and then every crate that either crossed a major version or went
+    // backwards, since those are the two ways this stops compiling.
+    let notable: Vec<&(String, String, Version)> = upgraded
         .iter()
         .filter(|(_, from, to)| {
-            Version::parse(from)
-                .map(|f| Bucket::of(&f) != Bucket::of(to))
-                .unwrap_or(false)
+            down(from, to)
+                || Version::parse(from)
+                    .map(|f| Bucket::of(&f) != Bucket::of(to))
+                    .unwrap_or(false)
         })
         .collect();
+    let backwards = upgraded.iter().filter(|(_, f, t)| down(f, t)).count();
     eprintln!(
-        "lock: upgraded {} crates, {} of them across a major version",
+        "lock: moved {} crates, {} across a major version, {} backwards",
         upgraded.len(),
-        major.len()
+        notable.len() - backwards,
+        backwards
     );
-    for (name, from, to) in &major {
-        eprintln!("lock: ^ {} {} -> {}", name, from, to);
+    for (name, from, to) in &notable {
+        eprintln!("lock: {} {} {} -> {}", mark(from, to), name, from, to);
     }
 }
 
@@ -2475,6 +2492,46 @@ mod lock_cmd_tests {
         assert!(out.contains("hashes = [\"ccc333\"]"));
         assert!(out.contains("indirect = True"));
         assert!(out.contains("rust_resolve("));
+    }
+
+    /// An upgrade can move a version backwards, and the report has to say so.
+    /// Taking the newest generic-array costs crypto-common a version, because
+    /// the newer crypto-common pins generic-array exactly. Found by running
+    /// --upgrade over rust-corpus.
+    #[test]
+    fn a_version_that_moved_backwards_is_not_reported_as_an_upgrade() {
+        let moved = vec![
+            (
+                "crypto-common".to_string(),
+                "0.1.7".to_string(),
+                Version::parse("0.1.6").unwrap(),
+            ),
+            (
+                "generic-array".to_string(),
+                "0.14.7".to_string(),
+                Version::parse("0.14.9").unwrap(),
+            ),
+        ];
+        // The marker is chosen per crate rather than for the run.
+        let back = Version::parse(&moved[0].1).unwrap() > moved[0].2;
+        let fwd = Version::parse(&moved[1].1).unwrap() < moved[1].2;
+        assert!(back, "crypto-common went backwards");
+        assert!(fwd, "generic-array went forwards");
+
+        // Both forms print without panicking, over and under the list limit.
+        report_upgrades(&moved, true);
+        let many: Vec<(String, String, Version)> = (0..40)
+            .map(|i| {
+                (
+                    format!("crate{}", i),
+                    "1.0.0".to_string(),
+                    Version::parse("1.1.0").unwrap(),
+                )
+            })
+            .chain(moved.clone())
+            .collect();
+        report_upgrades(&many, true);
+        report_upgrades(&many, false);
     }
 
     /// The acceptance test for --upgrade: deliberately old declarations move,


### PR DESCRIPTION
Follow-up to #46, found by running `lock --upgrade` over rust-corpus, which is what I should have done before that PR rather than after.

## What it printed

```
lock: ^ crypto-common 0.1.7 -> 0.1.6
```

That is not an upgrade.

## Why it happens, and why it is right

- crypto-common **0.1.7** requires `generic-array =0.14.7`, an exact pin
- crypto-common **0.1.6** requires `generic-array ^0.14.4`, a range

`--upgrade` moves generic-array to 0.14.9. crypto-common 0.1.7 forbids exactly that, so PubGrub backtracked and took crypto-common 0.1.6 in order to keep the newer generic-array. Trading one crate against another is what a backtracking solver is for.

The resolution is correct. The **report** was wrong, and a version silently going down during a command called `--upgrade` is the last thing that should be papered over.

## The change

A crate that moved backwards is marked `v` instead of `^`, and the summary counts it separately:

```
lock: moved 70 crates, 0 across a major version, 1 backwards
```

Past the list limit, crates that went backwards are always listed alongside the major bumps, since those are the two ways an upgrade stops compiling. Previously only major bumps were listed, so a backwards move in a large run was invisible.

## Verification at corpus scale

rust-corpus has **1,070 declarations, 292 of them direct**, five times this repo:

- `--upgrade` moved the graph and pulled in **42 new transitive crates** (1,070 to 1,112)
- a second run changed nothing, byte for byte
- the one backwards move is the crypto-common case above

187 tests pass, clippy clean, fmt clean.