### PR TITLE
Find the toolchain MSRV filtering compares against

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ so adding one crate does not churn the rest of the graph, and `--upgrade` is
 how you drop that preference. `--ignore-msrv` turns MSRV filtering off;
 `--greedy` selects the older non-backtracking resolver.
 
+The toolchain filtered against is the one your `rust_toolchain` declares,
+found wherever it is declared. `--toolchain-version 1.74.0` resolves for a
+different one. Declaring the toolchain in a different package from the crates
+is the ordinary case, and on rustc 1.74 `clap` reaches 4.5.61 rather than
+4.6.6, which needs 1.85.
+
 Declarations are shared by everyone working in the repo, so `lock` solves
 for every platform in `--targets` (linux x86_64 and both darwin arches by
 default) and declares the union. A linux developer adding `chrono` declares

--- a/tools/please_rust/src/sync.rs
+++ b/tools/please_rust/src/sync.rs
@@ -1134,9 +1134,15 @@ pub struct LockCmdArgs {
     pub greedy: bool,
 
     /// Ignore rust-version when selecting releases (MSRV filtering is on by
-    /// default, using the toolchain declared in the third-party BUILD file)
+    /// default, using the version the repo's rust_toolchain declares)
     #[arg(long)]
     pub ignore_msrv: bool,
+
+    /// The toolchain version to filter against, e.g. 1.97.1. Found from the
+    /// repo's `rust_toolchain` declaration when not given, which is what it
+    /// is for.
+    #[arg(long)]
+    pub toolchain_version: Option<String>,
 
     /// Features to enable on the crates being added (comma-separated).
     /// Optional dependencies these turn on are declared automatically.
@@ -1355,6 +1361,82 @@ fn report_upgrades(upgraded: &[(String, String, Version)], upgrading: bool) {
     );
     for (name, from, to) in &notable {
         eprintln!("lock: {} {} {} -> {}", mark(from, to), name, from, to);
+    }
+}
+
+/// The toolchain version MSRV filtering compares against.
+///
+/// It used to be scraped out of whichever file the declarations came from,
+/// which is only right when the toolchain happens to be declared beside them.
+/// This repo keeps them apart, so filtering was off here for every run: a
+/// crate needing a newer rustc was declared without complaint, and the
+/// warning written for exactly that case cannot fire while the filter is off.
+/// Since #20 a repo can have several declaration files, so where the
+/// toolchain sits is no longer a safe guess at all.
+///
+/// A rust_toolchain declares its version, so find it: the flag if given, the
+/// declarations file if it is there, then the repo.
+fn toolchain_for_msrv(args: &LockCmdArgs, build_text: &str) -> Option<Version> {
+    if let Some(v) = &args.toolchain_version {
+        match Version::parse(v) {
+            Ok(v) => return Some(v),
+            Err(e) => {
+                eprintln!("lock: --toolchain-version {} is not a version ({})", v, e);
+                return None;
+            }
+        }
+    }
+    if let Some(v) = crate::pubgrub_solver::toolchain_version(build_text) {
+        return Some(v);
+    }
+    let root = repo_root(&args.build_file);
+    let mut found: Vec<(PathBuf, Version)> = Vec::new();
+    for entry in walkdir::WalkDir::new(&root)
+        .max_depth(6)
+        .into_iter()
+        .filter_entry(|e| {
+            let n = e.file_name().to_string_lossy();
+            // plz-out holds generated BUILD files for every crate, and none
+            // of them declares a toolchain.
+            !(e.depth() > 0 && e.file_type().is_dir() && (n == "plz-out" || n.starts_with('.')))
+        })
+        .filter_map(Result::ok)
+    {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name != "BUILD" && name != "BUILD.plz" {
+            continue;
+        }
+        if let Ok(text) = fs::read_to_string(entry.path()) {
+            if let Some(v) = crate::pubgrub_solver::toolchain_version(&text) {
+                found.push((entry.path().to_path_buf(), v));
+            }
+        }
+    }
+    found.sort_by(|a, b| a.1.cmp(&b.1));
+    match found.len() {
+        0 => {
+            eprintln!(
+                "lock: no rust_toolchain found under {}, so MSRV filtering is off and a crate \
+                 needing a newer rustc than yours can be declared. Pass --toolchain-version to \
+                 say which rustc to resolve for.",
+                root.display()
+            );
+            None
+        }
+        1 => Some(found.remove(0).1),
+        _ => {
+            // The oldest, because a declaration set is shared and has to build
+            // for whoever has the oldest toolchain.
+            let names: Vec<String> = found
+                .iter()
+                .map(|(p, v)| format!("{} ({})", v, p.display()))
+                .collect();
+            eprintln!(
+                "lock: several rust_toolchain versions found, resolving for the oldest: {}",
+                names.join(", ")
+            );
+            Some(found.remove(0).1)
+        }
     }
 }
 
@@ -1757,11 +1839,7 @@ fn lock_round(
         let toolchain = if args.ignore_msrv {
             None
         } else {
-            let tc = crate::pubgrub_solver::toolchain_version(build_text);
-            if tc.is_none() {
-                eprintln!("lock: no rust_toolchain version found; MSRV filtering is off");
-            }
-            tc
+            toolchain_for_msrv(args, build_text)
         };
         solver.msrv(toolchain);
 
@@ -1929,6 +2007,7 @@ fn clone_lock_args(args: &LockCmdArgs) -> LockCmdArgs {
         ignore_msrv: args.ignore_msrv,
         features: args.features.clone(),
         upgrade: args.upgrade.clone(),
+        toolchain_version: args.toolchain_version.clone(),
     }
 }
 
@@ -2467,6 +2546,7 @@ mod lock_cmd_tests {
 
         lock(LockCmdArgs {
             upgrade: None,
+            toolchain_version: None,
             build_file: build_file.clone(),
             third_party_folder: "third_party/rust".to_string(),
             add: vec!["hexlib@0.4".to_string()],
@@ -2492,6 +2572,95 @@ mod lock_cmd_tests {
         assert!(out.contains("hashes = [\"ccc333\"]"));
         assert!(out.contains("indirect = True"));
         assert!(out.contains("rust_resolve("));
+    }
+
+    /// MSRV filtering compares against the toolchain the repo declares. It
+    /// used to be scraped from whichever file the declarations came from, so
+    /// a repo keeping the two apart resolved with no filter at all and said
+    /// so in a line that read as informational.
+    #[test]
+    fn the_toolchain_is_found_even_when_it_is_declared_elsewhere() {
+        let dir = std::env::temp_dir().join(format!("please_rust_msrv_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("third_party/rust")).unwrap();
+        fs::create_dir_all(dir.join("third_party/crates")).unwrap();
+        fs::write(dir.join(".plzconfig"), "").unwrap();
+        fs::write(
+            dir.join("third_party/rust/BUILD"),
+            "rust_toolchain(\n    name = \"toolchain\",\n    version = \"1.74.0\",\n)\n",
+        )
+        .unwrap();
+        let decls = dir.join("third_party/crates/BUILD");
+        fs::write(&decls, "").unwrap();
+
+        let args = |tv: Option<&str>| LockCmdArgs {
+            upgrade: None,
+            toolchain_version: tv.map(str::to_string),
+            build_file: decls.clone(),
+            third_party_folder: "third_party/crates".to_string(),
+            add: vec![],
+            index_url: "https://index.invalid".to_string(),
+            cache_dir: None,
+            offline: true,
+            target: "x86_64-unknown-linux-gnu".to_string(),
+            targets: "x86_64-unknown-linux-gnu".to_string(),
+            curl: "false".to_string(),
+            plz: "".to_string(),
+            greedy: false,
+            ignore_msrv: false,
+            features: None,
+        };
+
+        // The declarations file has no toolchain, so this is the case that
+        // used to silently disable filtering.
+        assert_eq!(
+            toolchain_for_msrv(&args(None), ""),
+            Some(Version::parse("1.74.0").unwrap())
+        );
+
+        // An explicit version wins over anything found.
+        assert_eq!(
+            toolchain_for_msrv(&args(Some("1.60.0")), ""),
+            Some(Version::parse("1.60.0").unwrap())
+        );
+
+        // A toolchain beside the declarations is still read without a search.
+        assert_eq!(
+            toolchain_for_msrv(
+                &args(None),
+                "rust_toolchain(\n    version = \"1.80.0\",\n)\n"
+            ),
+            Some(Version::parse("1.80.0").unwrap())
+        );
+
+        // Two disagreeing toolchains resolve for the oldest, because a
+        // declaration set is shared and has to build for whoever has the
+        // oldest rustc.
+        fs::create_dir_all(dir.join("services/other")).unwrap();
+        fs::write(
+            dir.join("services/other/BUILD"),
+            "rust_toolchain(\n    name = \"t2\",\n    version = \"1.70.0\",\n)\n",
+        )
+        .unwrap();
+        assert_eq!(
+            toolchain_for_msrv(&args(None), ""),
+            Some(Version::parse("1.70.0").unwrap())
+        );
+
+        // No toolchain anywhere is not an error, but it is not silent either.
+        let bare =
+            std::env::temp_dir().join(format!("please_rust_msrv_none_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&bare);
+        fs::create_dir_all(&bare).unwrap();
+        fs::write(bare.join(".plzconfig"), "").unwrap();
+        let bare_build = bare.join("BUILD");
+        fs::write(&bare_build, "").unwrap();
+        let mut a = args(None);
+        a.build_file = bare_build;
+        assert_eq!(toolchain_for_msrv(&a, ""), None);
+
+        let _ = fs::remove_dir_all(&dir);
+        let _ = fs::remove_dir_all(&bare);
     }
 
     /// An upgrade can move a version backwards, and the report has to say so.
@@ -2604,6 +2773,7 @@ mod lock_cmd_tests {
 
         let args = |upgrade| LockCmdArgs {
             upgrade,
+            toolchain_version: None,
             build_file: build_file.clone(),
             third_party_folder: "third_party/rust".to_string(),
             add: vec![],
@@ -2662,6 +2832,7 @@ mod lock_cmd_tests {
         fs::write(&build_file, "").unwrap();
         let err = lock(LockCmdArgs {
             upgrade: None,
+            toolchain_version: None,
             build_file,
             third_party_folder: "third_party/rust".to_string(),
             add: vec!["ghost@1".to_string()],
@@ -2824,6 +2995,7 @@ rust_resolve(
         let before = fs::read_to_string(&build_file).unwrap();
         lock(LockCmdArgs {
             upgrade: None,
+            toolchain_version: None,
             build_file: build_file.clone(),
             third_party_folder: "third_party/rust".to_string(),
             add: vec!["present@1".to_string()],


### PR DESCRIPTION
Closes #47.

## What was wrong

The toolchain version was scraped out of whichever file the declarations came from:

```rust
let tc = crate::pubgrub_solver::toolchain_version(build_text);
```

That is right only when the toolchain happens to be declared beside the crates. **This repo keeps them apart**, so every `lock` run here printed, four times, once per platform:

```
lock: no rust_toolchain version found; MSRV filtering is off
```

and resolved with no filter at all.

Three things made that worth fixing rather than shrugging at:

1. **The failure is silent and delayed.** A crate needing a newer rustc gets declared without complaint and fails later as a compile error inside a dependency nobody chose.
2. **It swallows its own diagnostic.** The `no release of X supports rustc Y` warning only fires when the filter is on, so the message written for exactly this case could never print.
3. **#20 made the assumption indefensible.** A repo can now have several declaration files, so "the toolchain is in the declarations file" is a coincidence rather than a default.

`lock` is run by a human rather than by a rule, so there was nothing to fill a flag in. That is why the code was scraping in the first place.

## The change

A `rust_toolchain` declares its version, so find it:

1. `--toolchain-version` if given
2. the declarations file, as before
3. otherwise **search the repo** for the `rust_toolchain` declaration

Two that disagree resolve for the **oldest**, because a declaration set is shared and has to build for whoever has the oldest rustc. The no-toolchain message now says what was lost and what to pass, rather than reading as a note.

## Demonstrated

`clap`'s 4.x releases each raise the floor, so the toolchain picks the answer:

| toolchain | clap reaches | because |
|---|---|---|
| 1.64.0 | 4.3.24 | 4.4.0 needs 1.70 |
| 1.70.0 | 4.4.18 | 4.5.0 needs 1.74 |
| 1.74.0 | 4.5.61 | 4.6.0 needs 1.85 |
| 1.97.1 | 4.6.6 | nothing newer |

With the toolchain in `third_party/rust/BUILD` and the crates in another package, and **no flag at all**, it finds 1.97.1 and reaches 4.6.6. That is the case that used to resolve unfiltered.

`lock` in this repo no longer prints the warning.

## Scope

Nothing here changes what this repo resolves to: our toolchain is 1.97.1 and **0 of 1,012 corpus declarations need anything newer**, so the filter has nothing to reject. The people this protects are on older toolchains.

188 tests pass, including a new one covering all four paths, clippy clean, fmt clean.