### PR TITLE
Relax MSRV per requirement, not just per bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ different one. Declaring the toolchain in a different package from the crates
 is the ordinary case, and on rustc 1.74 `clap` reaches 4.5.61 rather than
 4.6.6, which needs 1.85.
 
+Filtering never turns a solvable graph into an error. When nothing that
+builds on your toolchain satisfies a requirement, the newest release that
+does satisfy it is taken and named, along with the rustc it needs.
+
 Declarations are shared by everyone working in the repo, so `lock` solves
 for every platform in `--targets` (linux x86_64 and both darwin arches by
 default) and declares the union. A linux developer adding `chrono` declares

--- a/tools/please_rust/src/pubgrub_solver.rs
+++ b/tools/please_rust/src/pubgrub_solver.rs
@@ -206,6 +206,18 @@ impl<'a, S: ReleaseSource> Solver<'a, S> {
     /// skip yanked (unless pinned), then apply MSRV, relaxing it only if that
     /// would leave nothing to choose.
     fn candidates(&self, name: &str, bucket: Bucket) -> Result<Vec<Release>> {
+        Ok(self.candidates_split(name, bucket)?.0)
+    }
+
+    /// The same, but keeping what MSRV filtering removed.
+    ///
+    /// Whether a requirement is satisfiable depends on the requirement, and
+    /// this only knows the bucket. A bucket can keep plenty of releases and
+    /// still lose every one that a particular dependent asked for: thiserror
+    /// 2.x has eighteen releases that build on rustc 1.70 and none of them
+    /// satisfies ^2.0.20, because 2.0.20 needs 1.71. The caller has the
+    /// requirement, so it gets both halves and decides.
+    fn candidates_split(&self, name: &str, bucket: Bucket) -> Result<(Vec<Release>, Vec<Release>)> {
         let pinned = self.pinned.get(name);
         let mut in_bucket: Vec<Release> = self
             .releases(name)?
@@ -236,11 +248,16 @@ impl<'a, S: ReleaseSource> Solver<'a, S> {
                         name, bucket, toolchain
                     );
                 }
-                return Ok(in_bucket);
+                return Ok((in_bucket, Vec::new()));
             }
-            return Ok(ok);
+            let excluded: Vec<Release> = in_bucket
+                .iter()
+                .filter(|r| !ok.iter().any(|k| k.version == r.version))
+                .cloned()
+                .collect();
+            return Ok((ok, excluded));
         }
-        Ok(in_bucket)
+        Ok((in_bucket, Vec::new()))
     }
 
     /// Buckets a requirement can be satisfied by, newest bucket first.
@@ -305,11 +322,41 @@ impl<'a, S: ReleaseSource> Solver<'a, S> {
         bucket: Bucket,
         req: &VersionReq,
     ) -> Result<Ranges<Version>> {
+        let (ok, excluded) = self.candidates_split(package, bucket)?;
         let mut range = Ranges::empty();
-        for r in self.candidates(package, bucket)? {
+        for r in &ok {
             if req.matches(&r.version) {
-                range = range.union(&Ranges::singleton(r.version));
+                range = range.union(&Ranges::singleton(r.version.clone()));
             }
+        }
+        if !range.is_empty() {
+            return Ok(range);
+        }
+        // A bucket can keep most of its releases and still lose every one
+        // this requirement asked for. Refusing to resolve is worse than
+        // declaring a crate that needs a newer rustc, which is what the
+        // whole-bucket case already chooses; the difference is that leaving
+        // the range empty produces an error saying no release satisfies a
+        // requirement that several releases do satisfy.
+        if let Some(r) = excluded.iter().find(|r| req.matches(&r.version)) {
+            if self.relaxed.borrow_mut().insert(package.to_string()) {
+                eprintln!(
+                    "warning: nothing that satisfies {} {} builds on rustc {}; taking {}, \
+                     which needs rustc {}",
+                    package,
+                    req,
+                    self.msrv
+                        .as_ref()
+                        .map(|v| v.to_string())
+                        .unwrap_or_default(),
+                    r.version,
+                    r.rust_version
+                        .as_ref()
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "an unstated version".to_string()),
+                );
+            }
+            return Ok(Ranges::singleton(r.version.clone()));
         }
         Ok(range)
     }
@@ -436,8 +483,8 @@ impl<'a, S: ReleaseSource> DependencyProvider for Solver<'a, S> {
                     .find(|v| range.contains(v)))
             }
             Pkg::Crate { name, bucket } => {
-                let candidates = self
-                    .candidates(name, *bucket)
+                let (candidates, excluded) = self
+                    .candidates_split(name, *bucket)
                     .map_err(|e| SolverError(e.to_string()))?;
                 // An already-declared version wins when it is still in range,
                 // so `lock --add` does not churn unrelated crates.
@@ -450,10 +497,40 @@ impl<'a, S: ReleaseSource> DependencyProvider for Solver<'a, S> {
                         return Ok(Some(p.clone()));
                     }
                 }
-                Ok(candidates
-                    .into_iter()
-                    .map(|r| r.version)
-                    .find(|v| range.contains(v)))
+                if let Some(v) = candidates
+                    .iter()
+                    .map(|r| r.version.clone())
+                    .find(|v| range.contains(v))
+                {
+                    return Ok(Some(v));
+                }
+                // Nothing this toolchain can build satisfies the requirement,
+                // but something does. Refusing to resolve is worse than
+                // declaring a crate that may need a newer rustc, which is the
+                // same choice the whole-bucket case above already makes. Said
+                // out loud, because the alternative is an error claiming no
+                // release satisfies a requirement that several do.
+                if let Some(r) = excluded.iter().find(|r| range.contains(&r.version)) {
+                    if self.relaxed.borrow_mut().insert(name.to_string()) {
+                        eprintln!(
+                            "warning: no release of {} that supports rustc {} satisfies what \
+                             depends on it; taking {} {}, which needs rustc {}",
+                            name,
+                            self.msrv
+                                .as_ref()
+                                .map(|v| v.to_string())
+                                .unwrap_or_default(),
+                            name,
+                            r.version,
+                            r.rust_version
+                                .as_ref()
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "an unstated version".to_string()),
+                        );
+                    }
+                    return Ok(Some(r.version.clone()));
+                }
+                Ok(None)
             }
         }
     }
@@ -916,6 +993,40 @@ mod tests {
         let f = b.build();
         let got = solve_with(&f, &[("hard", "^1")], &[], Some("1.60.0")).unwrap();
         assert_eq!(got["hard"], Version::parse("1.0.0").unwrap());
+    }
+
+    /// A bucket can keep most of its releases and still lose every one a
+    /// particular requirement asked for. Found in rust-corpus at rustc 1.70:
+    /// thiserror 2.x has eighteen releases that build on 1.70 and none of
+    /// them satisfies ^2.0.20, because 2.0.20 needs 1.71. Resolution failed
+    /// with "no release of thiserror satisfies ^2.0.20", which is not true.
+    #[test]
+    fn msrv_relaxes_for_a_requirement_no_supported_release_satisfies() {
+        let mut b = idx();
+        // Plenty of the bucket builds on the toolchain, so the whole-bucket
+        // relaxation never fires.
+        b.add("t", "2.0.0", &[]);
+        b.add("t", "2.0.5", &[]);
+        b.add("t", "2.0.17", &[]);
+        // Only this one satisfies ^2.0.20, and it needs a newer rustc.
+        b.msrv_release("t", "2.0.20", "1.71.0");
+        let f = b.build();
+
+        let got = solve_with(&f, &[("t", "^2.0.20")], &[], Some("1.70.0")).unwrap();
+        assert_eq!(
+            got["t"],
+            Version::parse("2.0.20").unwrap(),
+            "the only release satisfying the requirement should be taken, with a warning"
+        );
+
+        // A requirement the toolchain can satisfy is unaffected: still the
+        // newest release that builds, not the newest release.
+        let got = solve_with(&f, &[("t", "^2")], &[], Some("1.70.0")).unwrap();
+        assert_eq!(got["t"], Version::parse("2.0.17").unwrap());
+
+        // And with no MSRV at all, the newest wins as before.
+        let got = solve_with(&f, &[("t", "^2")], &[], None).unwrap();
+        assert_eq!(got["t"], Version::parse("2.0.20").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Closes #50. Found by running `lock --upgrade --toolchain-version 1.70.0` over rust-corpus after #47 made MSRV filtering actually apply.

## What it said

```
Error: version conflict:
dependencies of the request are unavailable no release of thiserror satisfies ^2.0.20
```

Not true. `2.0.20` exists. MSRV filtering removed it because it needs rustc 1.71, and the error never mentions rustc, so a reader on 1.70 goes hunting for a yanked release when their compiler is one version too old.

## Why the existing escape hatch missed it

The relaxation was per **bucket**, firing only when filtering emptied one:

| thiserror | needs rustc |
|---|---|
| 2.0.0 - 2.0.17 | 1.61 |
| 2.0.18 | 1.68 |
| **2.0.19 - 2.0.20** | **1.71** |

Eighteen releases survive on 1.70, so the bucket is not empty and nothing relaxes, even though every release satisfying `^2.0.20` was filtered out. A bucket can keep most of its releases and still lose every one a particular requirement asked for.

## The change

A requirement that no supported release satisfies now takes the newest release that does, and says so:

```
warning: nothing that satisfies thiserror ^2.0.20 builds on rustc 1.70.0; taking 2.0.20, which needs rustc 1.71.0
```

This is the same choice the whole-bucket case already makes, and the existing comment states the principle: *"refusing to resolve is worse than building something that may need a newer rustc"*.

**Both halves are needed.** The allowed range is built from filtered candidates, so `bucket_range` has to admit the relaxed version, and `choose_version` has to be able to return it. Fixing only the second does nothing, because an empty range is rejected before a version is ever chosen. I found that out by fixing the second one first and watching the error not move.

## Result at rustc 1.70 on rust-corpus

Instead of stopping at thiserror it relaxes **140 crates**, each named:

```
warning: nothing that satisfies tokio ^1.53.1 builds on rustc 1.70.0; taking 1.53.1, which needs rustc 1.71.0
warning: nothing that satisfies indexmap ^2.14.0 builds on rustc 1.70.0; taking 2.14.0, which needs rustc 1.85.0
warning: nothing that satisfies log ^0.4.33 builds on rustc 1.70.0; taking 0.4.33, which needs rustc 1.71.0
```

and gets far enough to reach a **genuine** conflict, reported as one with real version lists:

```
Because actix-http 3.x 3.13.3 depends on tokio-util 0.7.x 0.7.0 | ... | 0.7.16
and the request depends on tokio-util 0.7.x 0.7.19, the request is forbidden.
```

That is a real incompatibility: on 1.70, actix-http accepts tokio-util only up to 0.7.16 while the declarations require 0.7.19. Resolving a 2026 dependency set on a 2023 compiler is not always possible, and now it fails for the right reason.

## No change at a current toolchain

- rust-corpus at 1.97.1: `nothing to do`, no warnings, declarations byte-identical
- rust-rules: `nothing to do`, no warnings

189 tests pass, including one covering the exact shape (a bucket that keeps most releases but loses every one satisfying the requirement), clippy clean, fmt clean.