### PR TITLE
Fetch a crate from each forge for real

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,7 @@ rust_project(
         "//third_party/crates:rust_lock",
         "//test/firstparty:firstparty_lock",
         "//test/links:links_lock",
+        "//test/forge_fetch:forge_lock",
         "//test/patch:patch_lock",
     ],
 )

--- a/test/forge_fetch/BUILD
+++ b/test/forge_fetch/BUILD
@@ -1,0 +1,66 @@
+subinclude("//build_defs:rust", "//build_defs:rust_repo")
+
+# A crate fetched from a forge that is not github.
+#
+# The archive URL is built per forge scheme, and the scheme was github's for
+# every host until #21. Asserting the URL is one thing; whether the bytes
+# arrive, extract to the layout rust_repo expects, and compile is another,
+# and only a real fetch answers it. codeberg runs forgejo, a gitea fork,
+# which serves github's /archive/<rev>.tar.gz.
+rust_repo(
+    name = "unit_prefix",
+    crate = "unit-prefix",
+    git_repo = "https://codeberg.org/commons-rs/unit-prefix",
+    git_revision = "v0.5.2",
+    lock = ":forge_lock",
+    third_party_path = "test/forge_fetch",
+    version = "0.5.2",
+)
+
+# gitlab serves a different scheme, /-/archive/<rev>/<name>-<rev>.tar.gz.
+# Its /archive/ path answers 403, so a gitlab crate declared as though it
+# were github fetches nothing.
+rust_repo(
+    name = "dunce",
+    crate = "dunce",
+    git_repo = "https://gitlab.com/kornelski/dunce",
+    git_revision = "v1.0.5",
+    lock = ":forge_lock",
+    third_party_path = "test/forge_fetch",
+    version = "1.0.5",
+)
+
+rust_resolve(
+    name = "forge_lock",
+    entries = [
+        "unit_prefix|unit-prefix|0.5.2||true|true",
+        "dunce|dunce|1.0.5||true|true",
+    ],
+)
+
+# A forge whose host says nothing about what it runs, which is the case
+# inference cannot get right: salsa.debian.org is gitlab. Only the download
+# is exercised, because the crate behind it is a binary with a dependency
+# graph this test has no use for.
+rust_git_download(
+    name = "salsa_download",
+    crate = "debcargo",
+    forge = "gitlab",
+    repo = "https://salsa.debian.org/rust-team/debcargo",
+    revision = "2.8.4",
+    version = "2.8.4",
+)
+
+genrule(
+    name = "salsa_fetch_test",
+    srcs = [":salsa_download"],
+    outs = ["salsa_fetch.txt"],
+    cmd = "grep -q '^name = \"debcargo\"' $SRCS/Cargo.toml && echo ok > $OUT",
+)
+
+rust_test(
+    name = "forge_fetch_test",
+    root = "forge_fetch_test.rs",
+    edition = "2021",
+    deps = [":unit_prefix", ":dunce"],
+)

--- a/test/forge_fetch/forge_fetch_test.rs
+++ b/test/forge_fetch/forge_fetch_test.rs
@@ -1,0 +1,26 @@
+// The crate under test came from codeberg rather than crates.io. If the
+// archive scheme were wrong the fetch would fail; this checks the source
+// that arrived is the crate we asked for and compiles.
+extern crate dunce;
+extern crate unit_prefix;
+
+use unit_prefix::NumberPrefix;
+
+#[test]
+fn a_crate_fetched_from_a_non_github_forge_works() {
+    match NumberPrefix::decimal(1_500_f64) {
+        NumberPrefix::Prefixed(prefix, n) => {
+            assert_eq!(prefix.symbol(), "k");
+            assert!((n - 1.5).abs() < 1e-9);
+        }
+        NumberPrefix::Standalone(n) => panic!("1500 should be prefixed, got {}", n),
+    }
+}
+
+#[test]
+fn a_crate_from_gitlab_works_too() {
+    // gitlab's archive scheme differs from github's, so this arriving at all
+    // is the assertion. dunce normalises windows paths and is a no-op here.
+    let p = std::path::Path::new("/tmp");
+    assert_eq!(dunce::simplified(p), p);
+}


### PR DESCRIPTION
Follow-up to #21, which is merged. That PR asserted the archive **URLs** at parse time. This checks the **bytes arrive and compile**.

## What runs now

| forge | scheme | what is proven |
|---|---|---|
| **codeberg** (forgejo/gitea) | `/archive/<rev>.tar.gz` | fetched, BUILD files generated, **compiled, test passes** |
| **gitlab.com** | `/-/archive/<rev>/<name>-<rev>.tar.gz` | fetched, generated, **compiled, test passes** |
| **salsa.debian.org** | gitlab on a host that does not say so, `git_forge = "gitlab"` | archive fetched, `name = "debcargo"` asserted inside it |

The third is the case inference cannot get right, and the only one that exercises the override. It is download-only on purpose: `debcargo` is a binary with a dependency graph this test has no use for, and 188KB of archive is enough to prove the URL reaches real bytes.

## Two things worth a decision

**This puts three third-party hosts in the CI path.** CI already fetches crates.io for every declaration, so the network is not a new dependency, but codeberg or salsa being down now fails a build here. If that is not wanted, these belong behind a label that CI can exclude, or in rust-corpus instead.

**No hashes are pinned.** A forge archive is not guaranteed byte-stable; gzip settings have changed under people before, and GitHub regenerated archives in 2023 breaking checksums across the ecosystem. A pinned hash gives integrity and can break on its own. For a crate nothing ships, no hash seemed the better trade, but a consumer pinning a fork should know the risk either way. Worth documenting, and worth its own issue if you want the rules to say something about it.

191 tests pass.